### PR TITLE
Fix app stuck on loading screen on webOS 5/6 (#1)

### DIFF
--- a/css/legacy-webos.css
+++ b/css/legacy-webos.css
@@ -1,0 +1,61 @@
+/*
+ * Legacy webOS compatibility — flex `gap` fallback.
+ *
+ * CSS `gap` for flexbox shipped in Chromium 84 (July 2020).
+ * webOS 5 (Chromium 68) and webOS 6 (Chromium 79) ignore it,
+ * leaving UI elements with no spacing. webOS 22 (Chromium 87)
+ * and newer support it natively.
+ *
+ * We use `@supports not (inset: 0)` (Chromium 87 introduced
+ * `inset`) as a proxy: false on webOS 22+ (gap works), true on
+ * webOS 5 & 6 (need fallback). On those older runtimes, `gap`
+ * is silently dropped and the margin rules below take effect;
+ * on newer runtimes, this whole block is skipped and `gap`
+ * does its thing — no double spacing.
+ */
+
+@supports not (inset: 0) {
+  /* settings.css */
+  .settings-row > * + * { margin-left: 16px; }
+  .settings-field > * + * { margin-top: 6px; }
+  .settings-actions > * + * { margin-left: 16px; }
+
+  /* channel-list.css */
+  .playlist-tabs > * + * { margin-left: 4px; }
+  .group-item > * + * { margin-left: 12px; }
+  .channel-list-scroll > * + * { margin-top: 4px; }
+  .channel-item > * + * { margin-left: 16px; }
+
+  /* player.css */
+  .osd-channel > * + * { margin-left: 16px; }
+  .osd-programme-detail > * + * { margin-left: 16px; }
+  .osd-programme-time > * + * { margin-left: 16px; }
+  .osd-progress-row > * + * { margin-left: 12px; }
+  .osd-next > * + * { margin-left: 12px; }
+  .player-sidebar .sidebar-tabs > * + * { margin-left: 4px; }
+  .player-sidebar .sidebar-channel-list > * + * { margin-top: 2px; }
+  .player-sidebar .sidebar-ch-item > * + * { margin-left: 14px; }
+  .player-sidebar .sidebar-ch-item .ch-info > * + * { margin-top: 2px; }
+  .player-menu .menu-items > * + * { margin-top: 6px; }
+  .player-menu .menu-item > * + * { margin-left: 14px; }
+
+  /* epg.css */
+  .epg-title > * + * { margin-left: 16px; }
+  .epg-day-bar > * + * { margin-left: 4px; }
+  .epg-channel-col > * + * { margin-left: 8px; }
+  .epg-info-content > * + * { margin-left: 16px; }
+
+  /* main.css */
+  .loading-container > * + * { margin-top: 24px; }
+
+  /* `backdrop-filter` is Chromium 76+. webOS 5 (68) ignores it,
+   * leaving the rgba background alone. The existing rgba alphas
+   * are already 0.75–0.92, so panels remain readable — but bump
+   * them to fully opaque on webOS 5 for safety. webOS 6 (79)
+   * supports backdrop-filter, so we don't need to cover it here. */
+  @supports not (backdrop-filter: blur(1px)) {
+    .player-sidebar { background: rgb(20, 20, 35); }
+    .player-menu,
+    .player-osd { background: rgb(10, 10, 15); }
+  }
+}

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -16,6 +16,7 @@ if (appinfo.version !== version) {
 cpSync('index.html', 'dist/index.html');
 cpSync('appinfo.json', 'dist/appinfo.json');
 cpSync('css', 'dist/css', { recursive: true });
+cpSync('webOSjs', 'dist/webOSjs', { recursive: true });
 cpSync('assets/icon80.png', 'dist/icon.png');
 cpSync('assets/icon130.png', 'dist/largeIcon.png');
 
@@ -24,12 +25,17 @@ const define = {
   '__APP_VERSION__': JSON.stringify(version),
   '__APP_ID__': JSON.stringify(appinfo.id),
 };
+// Target Chromium 68 — the engine on webOS 5. This down-levels ES2020+
+// syntax (`?.`, `??`, etc.) which would otherwise fail to parse on
+// webOS 5/6 and leave the app stuck on the loading screen.
+const TARGET = ['chrome68'];
+
 await esbuild.build({
   entryPoints: ['src/app.ts'],
   bundle: true,
   outfile: 'dist/js/app.js',
   format: 'iife',
-  target: 'es2020',
+  target: TARGET,
   minify: !isWatch,
   sourcemap: isWatch,
   external: ['hls.js', 'mpegts.js'],
@@ -42,7 +48,7 @@ await esbuild.build({
   bundle: true,
   outfile: 'dist/js/preview-libs.js',
   format: 'iife',
-  target: 'es2020',
+  target: TARGET,
   minify: true,
 });
 
@@ -52,7 +58,7 @@ if (isWatch) {
     bundle: true,
     outfile: 'dist/js/app.js',
     format: 'iife',
-    target: 'es2020',
+    target: TARGET,
     minify: false,
     sourcemap: true,
     external: ['hls.js', 'mpegts.js'],

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="css/player.css">
   <link rel="stylesheet" href="css/epg.css">
   <link rel="stylesheet" href="css/settings.css">
+  <link rel="stylesheet" href="css/legacy-webos.css">
 </head>
 <body>
   <video id="video-player" autoplay></video>

--- a/src/parsers/xmltv-parser.ts
+++ b/src/parsers/xmltv-parser.ts
@@ -6,7 +6,11 @@ const log = createLogger('XMLTV');
 
 export function parseXMLTV(xmlString: string): ParsedEpg {
   // Strip DOCTYPE to avoid DOMParser issues with external DTD references
-  const cleaned = xmlString.replace(/<!DOCTYPE[^>]*>/i, '');
+  let cleaned = xmlString.replace(/<!DOCTYPE[^>]*>/i, '');
+  // Escape stray ampersands that aren't already part of an entity. Many
+  // real-world XMLTV feeds contain unescaped `&` (e.g. in titles), which
+  // would otherwise abort parsing in strict 'text/xml' mode.
+  cleaned = cleaned.replace(/&(?!(?:[a-zA-Z][a-zA-Z0-9]*|#\d+|#x[0-9a-fA-F]+);)/g, '&amp;');
   const parser = new DOMParser();
   const doc = parser.parseFromString(cleaned, 'text/xml');
 

--- a/src/services/playlist-service.ts
+++ b/src/services/playlist-service.ts
@@ -15,8 +15,9 @@ class PlaylistServiceImpl {
   async load(): Promise<Channel[]> {
     const cached = StorageService.getCachedPlaylist();
     if (cached) {
-      log.info('Cache hit:', cached.length, 'channels');
-      this.channels = cached;
+      this.channels = cached.channels;
+      this.epgUrls = cached.epgUrls ?? [];
+      log.info('Cache hit:', this.channels.length, 'channels,', this.epgUrls.length, 'epg urls');
       this.buildGroups();
       this.buildPlaylistNames();
       return this.channels;
@@ -82,8 +83,8 @@ class PlaylistServiceImpl {
     this.epgUrls = epgUrls;
     this.buildGroups();
     this.buildPlaylistNames();
-    StorageService.setCachedPlaylist(allChannels);
-    log.info('Refresh complete:', allChannels.length, 'total channels');
+    StorageService.setCachedPlaylist(allChannels, epgUrls);
+    log.info('Refresh complete:', allChannels.length, 'total channels,', epgUrls.length, 'epg urls');
     done();
     return allChannels;
   }

--- a/src/services/storage-service.ts
+++ b/src/services/storage-service.ts
@@ -89,15 +89,15 @@ export const StorageService = {
     set('auto_play', val);
   },
 
-  getCachedPlaylist(): Channel[] | null {
-    const data = get<{ channels: Channel[]; timestamp: number } | null>('cached_playlist', null);
+  getCachedPlaylist(): { channels: Channel[]; epgUrls: string[] } | null {
+    const data = get<{ channels: Channel[]; epgUrls?: string[]; timestamp: number } | null>('cached_playlist', null);
     if (!data || Date.now() - data.timestamp > CONFIG.PLAYLIST_REFRESH_INTERVAL) return null;
     if (!data.channels || data.channels.length === 0) return null;
-    return data.channels;
+    return { channels: data.channels, epgUrls: data.epgUrls ?? [] };
   },
-  setCachedPlaylist(channels: Channel[]): void {
+  setCachedPlaylist(channels: Channel[], epgUrls: string[] = []): void {
     if (!channels.length) return;
-    set('cached_playlist', { channels, timestamp: Date.now() });
+    set('cached_playlist', { channels, epgUrls, timestamp: Date.now() });
   },
 
   getCachedEpg(): ParsedEpg | null {

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -8,7 +8,7 @@ export function parseXmltvDate(str: string | null): Date | null {
 }
 
 export function formatTime(date: Date): string {
-  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hourCycle: 'h23' });
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
 }
 
 export function formatDate(date: Date): string {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2018",
     "module": "ES2020",
     "moduleResolution": "bundler",
     "strict": true,

--- a/webOSjs/webOS.js
+++ b/webOSjs/webOS.js
@@ -1,0 +1,76 @@
+/**
+ * Minimal webOS.js shim
+ *
+ * Implements just enough of the official LG `webOS.js` library for this app:
+ *   - webOS.platformBack()
+ *   - webOS.service.request(uri, params)   // wraps PalmServiceBridge
+ *
+ * PalmServiceBridge is a built-in webOS TV browser global that dispatches
+ * Luna service calls. This shim avoids shipping LG's proprietary webOS.js.
+ */
+(function (global) {
+  'use strict';
+
+  function isWebOS() {
+    return /webOS|Web0S/i.test(navigator.userAgent) ||
+      typeof global.PalmServiceBridge !== 'undefined';
+  }
+
+  if (!isWebOS()) return;
+
+  function serviceRequest(uri, params) {
+    params = params || {};
+    var method = params.method || '';
+    var parameters = params.parameters || {};
+    var onSuccess = params.onSuccess || function () {};
+    var onFailure = params.onFailure || function () {};
+    var onComplete = params.onComplete || function () {};
+    var subscribe = !!(params.subscribe || parameters.subscribe);
+
+    var url = uri + (method ? '/' + method : '');
+    var bridge;
+    try {
+      bridge = new global.PalmServiceBridge();
+    } catch (e) {
+      onFailure({ errorCode: -1, errorText: 'PalmServiceBridge unavailable' });
+      onComplete();
+      return { cancel: function () {} };
+    }
+
+    bridge.onservicecallback = function (msg) {
+      var response;
+      try { response = JSON.parse(msg); } catch (e) { response = {}; }
+      if (response && (response.returnValue === false || response.errorCode)) {
+        onFailure(response);
+      } else {
+        onSuccess(response);
+      }
+      if (!subscribe) onComplete();
+    };
+
+    var payload = {};
+    for (var k in parameters) if (parameters.hasOwnProperty(k)) payload[k] = parameters[k];
+    if (subscribe) payload.subscribe = true;
+
+    bridge.call(url, JSON.stringify(payload));
+
+    return {
+      cancel: function () {
+        try { bridge.cancel(); } catch (e) { /* ignore */ }
+        onComplete();
+      },
+    };
+  }
+
+  function platformBack() {
+    serviceRequest('luna://com.webos.service.applicationmanager', {
+      method: 'launch',
+      parameters: { id: 'com.webos.app.home' },
+    });
+  }
+
+  global.webOS = global.webOS || {};
+  global.webOS.platformBack = platformBack;
+  global.webOS.service = global.webOS.service || {};
+  global.webOS.service.request = serviceRequest;
+})(window);


### PR DESCRIPTION
Fixes #1

The bundle was built with esbuild target 'es2020', leaving optional chaining and nullish coalescing in the output. Both require Chromium 80+, but webOS 5 ships Chromium 68 and webOS 6 ships Chromium 79, so the script throws SyntaxError at parse time, App.init() never runs, and the loading spinner stays forever. Lower the build target to chrome68 so esbuild down-levels modern syntax. Tighten tsconfig target to ES2018 to match.

Other compatibility and robustness fixes:

- src/utils/time.ts: hourCycle is Chromium 73+; use hour12: false.
- webOSjs/webOS.js: ship a minimal PalmServiceBridge shim. Commit 1e68eb6 added a script tag for webOSjs/webOS.js but never added the file or wired up the build to copy it, so the Luna-based background-suspend path silently never ran on any TV.
- esbuild.config.mjs: copy webOSjs/ into dist/.
- src/parsers/xmltv-parser.ts: pre-escape stray ampersands so real-world XMLTV feeds don't kill the entire EPG under strict 'text/xml' parsing.
- src/services/{storage,playlist}-service.ts: persist epgUrls in the cached_playlist entry so the embedded url-tvg fallback survives cache hits.
- src/app.ts: wrap loadData() in try/finally so the loading view is always hidden.
- css/legacy-webos.css: flexbox 'gap' is Chromium 84+; webOS 5/6 silently drop it. Add margin-based equivalents inside @supports not (inset: 0), which is true only on Chromium <87, so webOS 22+ keeps native gap with no double-spacing. Also add an opaque-background fallback for backdrop-filter on webOS 5.