### PR TITLE
Add audio-track selection with per-channel memory

### DIFF
--- a/css/player.css
+++ b/css/player.css
@@ -448,6 +448,7 @@
   color: var(--text-primary);
   cursor: pointer;
   transition: var(--transition);
+  white-space: nowrap; /* keep a row's label on one line; the value chip ellipsizes instead */
 }
 
 .player-menu .menu-item.focused {
@@ -471,3 +472,56 @@
 .menu-dot.green { background: #2ecc71; }
 .menu-dot.yellow { background: #f1c40f; }
 .menu-dot.blue { background: #3498db; }
+
+/* Glyph in the colour-dot slot */
+.menu-icon {
+  width: 14px;
+  flex-shrink: 0;
+  text-align: center;
+  font-size: 18px;
+  line-height: 1;
+}
+.menu-icon.audio { color: #9b59b6; }
+
+/* Current audio track shown on the "Audio Track" row */
+.player-menu .menu-item-value {
+  margin-left: auto;
+  padding-left: 12px;
+  font-size: 16px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0; /* allow the chip to shrink (and ellipsize) so the label keeps its line */
+  max-width: 140px;
+}
+
+/* Fixed check / chevron column in the audio sub-menu so labels align */
+.player-menu .menu-check {
+  width: 18px;
+  flex-shrink: 0;
+  text-align: center;
+  color: #2ecc71;
+  font-weight: 700;
+}
+
+.player-menu .menu-check.menu-back {
+  color: var(--text-primary);
+  font-size: 26px;
+  line-height: 1;
+}
+
+.player-menu .menu-track-label {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.player-menu .menu-item.unavailable {
+  opacity: 0.4;
+}
+.player-menu .menu-item.unavailable.focused {
+  opacity: 0.6;
+}

--- a/docs/audio-track-selection.md
+++ b/docs/audio-track-selection.md
@@ -1,0 +1,150 @@
+# Selecting the audio track on the native webOS player
+
+How this app switches between multiple audio tracks (multi-language / accessibility
+renditions) when playing through the **native `<video>` element** on webOS — the path used
+on-device (`src/components/player.ts`, the `isWebOS` branch; helpers in
+`src/utils/audio-tracks.ts`). Everything below was **verified on-device** (firmware
+`33.31.61`, Chromium 120, UA `Web0S; Linux/SmartTV`, an LG OLED C5), not just inferred from
+binaries.
+
+## TL;DR
+
+- **Switch with the HTML5 API:** `video.audioTracks[i].enabled = true` (enabling one disables
+  the rest). LG's Chromium maps this onto the media pipeline's `selectTrack` internally — and
+  crucially, **bounded to the tracks the pipeline actually demuxed**, so it can't break playback.
+- **Do NOT call `com.webos.media/selectTrack` yourself.** The `<video>` element *does* expose a
+  `mediaId` and that Luna call *is* reachable — but it accepts out-of-range indices and then
+  fires a decode error that **kills the stream**. The HTML5 API is the safe front door.
+- **webOS exposes one `AudioTrack` per _distinct_ `LANGUAGE`**, with empty `label`/`language`.
+  So (a) same-language alternates are hidden, and (b) real names must be parsed from the master
+  `.m3u8`.
+
+```ts
+// Safe switch — valid only for the tracks webOS actually exposed (see the rule below).
+function selectAudioTrack(video: HTMLVideoElement, index: number) {
+  const list = video.audioTracks;
+  if (!list || index < 0 || index >= list.length) return;
+  for (let i = 0; i < list.length; i++) list[i].enabled = (i === index);
+}
+```
+
+## How many tracks you actually get — the LANGUAGE-collapse rule
+
+webOS surfaces **one HTML5 `AudioTrack` per distinct `LANGUAGE`** in the master playlist.
+Renditions that share a language code collapse to one — the pipeline loads only the `DEFAULT`
+among them. Verified on-device:
+
+| Master playlist | distinct `LANGUAGE` | native `audioTracks.length` |
+|---|---|---|
+| 3 renditions, all the **same** language | 1 | **1** |
+| 2 renditions, **2** distinct languages | 2 | **2** |
+| 3 renditions, **3** distinct languages | 3 | **3** |
+
+A stream that tags all its renditions with the **same** language collapses them to one — those
+same-language alternates are **not reachable** via the native path at all; only hls.js (which
+loads each rendition's separate audio playlist) could switch them.
+
+The exposed tracks arrive — sometimes asynchronously, via `addtrack` — with **empty `label`,
+`language`, and `kind`** for the alternates; only the default usually carries a language:
+
+```
+AUDIOTRACKS: 3 tracks -> [0] "" lang=l1 enabled=true [1] "" lang= enabled=false [2] "" lang=l2 enabled=false
+AUDIOTRACKS: 1 tracks -> [0] "" lang=l1 enabled=true        # all-same-language stream, collapsed to 1
+```
+
+React to `addtrack` (and re-check on `loadedmetadata`) since the list can fill in after metadata.
+
+## Switching: `audioTracks[i].enabled` (the supported path)
+
+Setting `.enabled` triggers, inside LG's engine:
+
+```
+video.audioTracks[i].enabled = true                          // app JS
+  → RendererImpl::OnEnabledAudioTracksChanged                 (libcbe.so)
+  → uMediaServer::uMediaClient::selectTrack("audio", i)       (libcbe.so)
+  → StarfishMediaAPIs::SelectTrack({ type:"audio", index:i }) (starfish-media-pipeline)
+  → com.webos.media pipeline selectTrack
+```
+
+Because the index space is the **HTML5 list** (only the demuxed tracks), you can't ask for a
+track the pipeline never loaded — which is exactly what makes it safe.
+
+**Expect a switch lag.** The pipeline keeps playing already-buffered audio of the old track
+until the playhead drains it, so the new track isn't audible for a few seconds (longer on big
+VOD buffers; ~seconds at a live edge). The app shows a *"Switching audio track to …"* toast as
+feedback.
+
+## Why not `com.webos.media/selectTrack` directly
+
+You might assume a `<video>` web app can't reach the pipeline directly. It can — but you still
+shouldn't, for a different reason:
+
+- The `<video>` element exposes a **`mediaId`** (e.g. `mediaId=_0NsNkKxKetdf8a`) and an
+  `onpipelinestarted` hook.
+- `luna://com.webos.media/selectTrack {mediaId, type:"audio", index}` **is reachable and returns
+  `{returnValue:true, errorText:"No Error"}`**.
+- **But it is unsafe.** It accepts indices the pipeline never demuxed and then throws a **decode
+  error** (`MediaError.code === 3`), breaking the stream; follow-up calls return
+  `returnValue:false`. On a stream that collapses to 1 native track, `selectTrack` to index 1
+  returned "No Error" and immediately killed playback.
+- Admin methods are **ACL-denied** to the app: `getActivePipelines` / `getPipelineState` →
+  `Denied method call ... for category "/"`; `subscribe` is not handled at the root category.
+
+So `selectTrack` adds nothing over `.enabled` except the ability to crash the decoder. Use
+`.enabled`.
+
+## Real track names — parse the master playlist
+
+Because native `audioTracks` carry empty `label`/`language` for the alternates, the picker would
+otherwise read "Audio 2". Fix: fetch the master `.m3u8`, read each `EXT-X-MEDIA:TYPE=AUDIO`
+`NAME`/`LANGUAGE`, and overlay them onto the native tracks **by index, only when the counts
+match** (so a collapsed list isn't mislabelled):
+
+- `parseAudioRenditions()` and `mergeManifestNames()` in `src/utils/audio-tracks.ts` (pure,
+  unit-tested).
+- `Player.loadManifestAudio()` fetches/parses on tune-in (webOS HLS only) and re-applies the
+  saved pick once the names are known. Degrades to generic labels on a fetch/parse failure.
+
+## Per-channel memory
+
+The chosen track is remembered per channel (keyed by `channelKey`) as `{ name, language }` and
+re-applied on the next tune-in — matched by name, then language, else the stream default. The
+manifest names are what make this reliable; the empty-metadata native tracks alone can't be keyed.
+
+## Desktop preview (hls.js)
+
+The desktop preview drives playback with **hls.js**, which exposes every rendition with real
+names — switch with `hls.audioTrack = i` (and read `hls.audioTracks`). The native-path manifest
+overlay is webOS-only. `mpegts.js` exposes only the first audio track (no switching). See the
+`this.hls` branches in `player.ts`.
+
+## Evidence (firmware `33.31.61`, Chromium 120, chassis `o22n3` / `papikonda`)
+
+The platform selects the manifest `DEFAULT` rendition; no layer auto-prefers audio description
+for an app's HLS stream:
+
+| Layer | Behavior (from binary strings) |
+|---|---|
+| `adaptiveng` HLS demuxer | Parses `EXT-X-MEDIA` incl. `DEFAULT`/`AUTOSELECT`; `gst_adaptive_demux_period_select_default_tracks`, `Selecting default audio track %s`, `Sort by SELECT flag` |
+| `umediaserver` `selectTrackByPreference` | Keys on **`languageCode`** only — not audio description |
+| `audiod` + "Audio Description" setting | A DVB broadcast **receiver-mix** (`audioDescriptionVolume.xml`, region-gated `EU_AU_HK_CN`) — not HLS rendition selection |
+| `com.webos.app.tvhotkey` Multi-Audio menu | Broadcast only: `setAudioLanguage({category:"channel"})`; never `selectTrack` on app media |
+| `WebMediaPlayerUMS` (Chromium adapter) | Reflects the platform-selected track; tracks a sticky `userSelectedAudioTrack`; `Only one enabled audio track is supported` |
+
+- `usr/lib/libcbe.so` — `AudioTrackList`, `audioTracks`, `OnEnabledAudioTracksChanged`,
+  `OnSelectedAudioTrackChanged`, and `uMediaServer::uMediaClient::selectTrack(std::string&, int)`.
+- `usr/sbin/starfish-media-pipeline` — `StarfishMediaAPIs::SelectTrack`, `selectTrack`,
+  `selectTrackByPreference`, `numAudioTracks`, `audioTrackInfo`, `sourceInfo` / `programInfo`.
+
+LG open source:
+- [`webosose/chromium68` — `umediaclient_impl.cc`](https://github.com/webosose/chromium68/blob/master/src/media/blink/neva/webos/umediaclient_impl.cc)
+  — audio tracks built from `sourceInfo.programInfo[0].numAudioTracks` → `add_audio_track_cb_`
+  (HTML5 `AudioTrackList`); `SelectTrack(type, id)`. *(In OSE the body is `NOTIMPLEMENTED()`;
+  implemented in the commercial TV firmware above.)*
+- [`webosose/umediaserver`](https://github.com/webosose/umediaserver) and the
+  [`com.webos.media` LS2 API](https://www.webosose.org/docs/reference/ls2-api/com-webos-media/).
+
+---
+
+*Verified on-device against the extracted LG firmware (`33.31.61`, chassis `o22n3` / `papikonda`)
+and live testing on an LG OLED C5 (2025).*

--- a/src/app.ts
+++ b/src/app.ts
@@ -70,6 +70,8 @@ class App {
       this.views.player,
       () => this.player.getCurrentIndex(),
       (action) => this.onMenuAction(action),
+      () => this.player.getAudioTracks(),
+      (index) => this.player.selectAudioTrack(index),
     );
 
     KeyHandler.init();
@@ -386,7 +388,8 @@ class App {
         if (this.sidebar.visible) {
           this.sidebar.hide();
         } else if (this.menu.visible) {
-          this.menu.hide();
+          // Let the menu step out of its audio sub-menu before closing.
+          if (!this.menu.handleBack()) this.menu.hide();
         } else {
           this.player.handleAction('back');
         }

--- a/src/components/player-menu.test.ts
+++ b/src/components/player-menu.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import type { Channel } from '../types';
+import type { Channel, AudioTrackOption } from '../types';
 
 const { channels } = vi.hoisted(() => {
   function makeChannel(over: Partial<Channel>): Channel {
@@ -22,10 +22,16 @@ vi.mock('../services/playlist-service', () => ({
 
 import { PlayerMenu } from './player-menu';
 
+// Number of colour actions before the "Audio Track" row in the main menu.
+const MENU_ACTIONS = 4;
+
 let container: HTMLElement;
 let el: HTMLElement;
 let getCurrentIndex: ReturnType<typeof vi.fn>;
 let onAction: ReturnType<typeof vi.fn>;
+let getAudioTracks: ReturnType<typeof vi.fn>;
+let selectAudioTrack: ReturnType<typeof vi.fn>;
+let audioTracks: AudioTrackOption[];
 let menu: PlayerMenu;
 
 beforeEach(() => {
@@ -39,7 +45,10 @@ beforeEach(() => {
 
   getCurrentIndex = vi.fn(() => 0);
   onAction = vi.fn();
-  menu = new PlayerMenu(container, getCurrentIndex, onAction);
+  audioTracks = [];
+  getAudioTracks = vi.fn(() => audioTracks);
+  selectAudioTrack = vi.fn();
+  menu = new PlayerMenu(container, getCurrentIndex, onAction, getAudioTracks, selectAudioTrack);
 });
 
 afterEach(() => {
@@ -124,5 +133,96 @@ describe('PlayerMenu', () => {
     menu.show();
     vi.advanceTimersByTime(5000);
     expect(menu.visible).toBe(false);
+  });
+
+  describe('audio track sub-menu', () => {
+    const TRACKS: AudioTrackOption[] = [
+      { index: 0, label: 'Track 1', active: true },
+      { index: 1, label: 'Track 2', active: false },
+      { index: 2, label: 'Track 3', active: false },
+    ];
+
+    it('omits the Audio Track row when fewer than two tracks', () => {
+      audioTracks = [{ index: 0, label: 'Track 1', active: true }];
+      menu.show();
+      expect(el.querySelector('[data-menu-action="__audio_open__"]')).toBeNull();
+    });
+
+    it('shows the Audio Track row with the active track when multiple exist', () => {
+      audioTracks = TRACKS;
+      menu.show();
+      const row = el.querySelector('[data-menu-action="__audio_open__"]');
+      expect(row).not.toBeNull();
+      expect(row!.querySelector('.menu-item-value')!.textContent).toBe('Track 1');
+    });
+
+    it('opens the picker listing all tracks plus a Back row, focusing the active one', () => {
+      audioTracks = TRACKS;
+      menu.show();
+      for (let i = 0; i < MENU_ACTIONS; i++) menu.handleAction('down'); // reach Audio Track row
+      menu.handleAction('select');
+      const rows = items();
+      expect(rows).toHaveLength(4);
+      expect(rows[0].dataset.menuAction).toBe('__audio_back__');
+      expect(rows.slice(1).map(r => r.dataset.trackIndex)).toEqual(['0', '1', '2']);
+      expect(rows[1].textContent).toContain('Track 1');
+      expect(rows[1].querySelector('.menu-check')!.textContent).toBe('✓'); // active marked
+      expect(rows[2].querySelector('.menu-check')!.textContent).toBe('');  // others blank
+      // active track (Track 1) is focused: Back row is index 0, Track 1 is index 1
+      expect(rows[1].classList.contains('focused')).toBe(true);
+    });
+
+    it('greys a track marked unavailable (a collapsed rendition), not the others', () => {
+      audioTracks = [
+        { index: 0, label: 'Track 1', active: true },
+        { index: 1, label: 'Track 2', active: false, available: false },
+        { index: 2, label: 'Track 3', active: false, available: false },
+      ];
+      menu.show();
+      for (let i = 0; i < MENU_ACTIONS; i++) menu.handleAction('down');
+      menu.handleAction('select');
+      const rows = items();
+      expect(rows[1].classList.contains('unavailable')).toBe(false); // Track 1 switchable
+      expect(rows[2].classList.contains('unavailable')).toBe(true);  // Track 2 greyed
+      expect(rows[3].classList.contains('unavailable')).toBe(true);  // Track 3 greyed
+    });
+
+    it('selecting a track switches to it and returns to the main menu', () => {
+      audioTracks = TRACKS;
+      menu.show();
+      for (let i = 0; i < MENU_ACTIONS; i++) menu.handleAction('down');
+      menu.handleAction('select');     // open picker (Track 1 focused at idx 1)
+      menu.handleAction('down');       // focus Track 3 (idx 3) ... step once → Track 2
+      menu.handleAction('down');       // → Track 3
+      menu.handleAction('select');     // pick it
+      expect(selectAudioTrack).toHaveBeenCalledWith(2);
+      // back on the main menu
+      expect(el.querySelector('[data-menu-action="__audio_open__"]')).not.toBeNull();
+      expect(menu.visible).toBe(true);
+    });
+
+    it('Back row returns to the main menu without closing', () => {
+      audioTracks = TRACKS;
+      menu.show();
+      for (let i = 0; i < MENU_ACTIONS; i++) menu.handleAction('down');
+      menu.handleAction('select');     // open picker
+      menu.handleAction('up');         // focus Back row (idx 0)
+      menu.handleAction('select');
+      expect(selectAudioTrack).not.toHaveBeenCalled();
+      expect(el.querySelector('[data-menu-action="__audio_open__"]')).not.toBeNull();
+      expect(menu.visible).toBe(true);
+    });
+
+    it('handleBack() leaves the picker but keeps the menu open; returns false on the main menu', () => {
+      audioTracks = TRACKS;
+      menu.show();
+      for (let i = 0; i < MENU_ACTIONS; i++) menu.handleAction('down');
+      menu.handleAction('select');     // in picker
+      expect(menu.handleBack()).toBe(true);
+      expect(menu.visible).toBe(true);
+      expect(el.querySelector('[data-menu-action="__audio_open__"]')).not.toBeNull();
+      // on the main menu it no longer consumes Back
+      expect(menu.handleBack()).toBe(false);
+    });
   });
 });

--- a/src/components/player-menu.ts
+++ b/src/components/player-menu.ts
@@ -1,4 +1,4 @@
-import type { Action } from '../types';
+import type { Action, AudioTrackOption } from '../types';
 import { PlaylistService } from '../services/playlist-service';
 import { $, html } from '../utils/dom';
 import { morph } from '../utils/morph';
@@ -12,27 +12,41 @@ const MENU_ITEMS = [
   { action: 'blue' as const, color: 'blue', label: 'Settings' },
 ];
 
+// Sentinel data-menu-action values for the non-colour rows.
+const OPEN_AUDIO = '__audio_open__';
+const BACK = '__audio_back__';
+const PICK_AUDIO = '__audio_track__';
+
 /**
  * The action overlay shown on the right edge during playback. Owns its own
- * visibility, auto-hide timer and focus index. Selecting an item hides the
+ * visibility, auto-hide timer and focus index. Selecting a colour item hides the
  * menu and emits the chosen action via `onAction`; the host decides how to
- * route it. Delegated DOM listeners are bound once in the constructor.
+ * route it. When the stream has multiple audio tracks an "Audio Track" row opens
+ * an in-place sub-menu for picking one. Delegated DOM listeners are bound once
+ * in the constructor.
  */
 export class PlayerMenu {
   private el: HTMLElement | null;
   private getCurrentIndex: () => number;
   private onAction: (action: Action) => void;
+  private getAudioTracks: () => AudioTrackOption[];
+  private selectAudioTrack: (index: number) => void;
   private isVisible = false;
   private timer: ReturnType<typeof setTimeout> | null = null;
   private focusIdx = 0;
+  private mode: 'main' | 'audio' = 'main';
 
   constructor(
     container: HTMLElement,
     getCurrentIndex: () => number,
     onAction: (action: Action) => void,
+    getAudioTracks: () => AudioTrackOption[],
+    selectAudioTrack: (index: number) => void,
   ) {
     this.getCurrentIndex = getCurrentIndex;
     this.onAction = onAction;
+    this.getAudioTracks = getAudioTracks;
+    this.selectAudioTrack = selectAudioTrack;
     this.el = $('#player-menu', container);
     this.bindEvents();
   }
@@ -44,6 +58,7 @@ export class PlayerMenu {
   show(): void {
     if (this.isVisible) return;
     this.isVisible = true;
+    this.mode = 'main';
     this.focusIdx = 0;
     this.render();
     if (this.el) {
@@ -81,6 +96,16 @@ export class PlayerMenu {
     }, AUTO_HIDE_MS);
   }
 
+  /** Back inside the menu: leave the audio sub-menu without closing. Returns
+   *  whether it was consumed (so the host knows not to hide the menu). */
+  handleBack(): boolean {
+    if (this.mode === 'audio') {
+      this.openMain();
+      return true;
+    }
+    return false;
+  }
+
   handleAction(action: Action): void {
     if (!this.el) return;
     const items = this.el.querySelectorAll<HTMLElement>('.menu-item');
@@ -94,8 +119,8 @@ export class PlayerMenu {
     } else if (action === 'down') {
       this.focusIdx = Math.min(len - 1, this.focusIdx + 1);
     } else if (action === 'select') {
-      const act = items[this.focusIdx]?.dataset.menuAction as Action;
-      if (act) this.activate(act);
+      const item = items[this.focusIdx];
+      if (item) this.selectItem(item);
       return;
     }
 
@@ -104,17 +129,52 @@ export class PlayerMenu {
     });
   }
 
-  private activate(action: Action): void {
-    this.hide();
-    this.onAction(action);
+  /** Route a selected/clicked row by its data-menu-action. */
+  private selectItem(item: HTMLElement): void {
+    const action = item.dataset.menuAction;
+    if (action === OPEN_AUDIO) {
+      this.openAudio();
+    } else if (action === BACK) {
+      this.openMain();
+    } else if (action === PICK_AUDIO) {
+      const idx = Number(item.dataset.trackIndex);
+      if (!Number.isNaN(idx)) this.selectAudioTrack(idx);
+      this.openMain();
+    } else if (action) {
+      this.hide();
+      this.onAction(action as Action);
+    }
+  }
+
+  private openAudio(): void {
+    this.mode = 'audio';
+    const tracks = this.getAudioTracks();
+    const active = tracks.findIndex(t => t.active);
+    this.focusIdx = active >= 0 ? active + 1 : 0; // +1 for the Back row
+    this.render();
+    this.resetTimer();
+  }
+
+  private openMain(): void {
+    this.mode = 'main';
+    this.focusIdx = 0;
+    this.render();
+    this.resetTimer();
   }
 
   private render(): void {
+    if (this.mode === 'audio') this.renderAudio();
+    else this.renderMain();
+  }
+
+  private renderMain(): void {
     const el = this.el;
     if (!el) return;
 
     const ch = PlaylistService.getByIndex(this.getCurrentIndex());
     const chName = ch?.name || '';
+    const tracks = this.getAudioTracks();
+    const activeTrack = tracks.find(t => t.active);
 
     morph(el, html`
       <div class="menu-header">
@@ -129,6 +189,39 @@ export class PlayerMenu {
             <span class="menu-dot ${item.color}"></span> ${item.label}
           </div>
         `)}
+        ${tracks.length >= 2 ? html`
+          <div class="menu-item ${MENU_ITEMS.length === this.focusIdx ? 'focused' : ''}"
+               data-focusable data-menu-action="${OPEN_AUDIO}">
+            <span class="menu-icon audio">♫</span> Audio Track
+            <span class="menu-item-value">${activeTrack?.label || ''}</span>
+          </div>
+        ` : ''}
+      </div>
+    `);
+  }
+
+  private renderAudio(): void {
+    const el = this.el;
+    if (!el) return;
+
+    const tracks = this.getAudioTracks();
+
+    morph(el, html`
+      <div class="menu-header">
+        <h2>Audio Track</h2>
+      </div>
+      <div class="menu-items">
+        <div class="menu-item ${this.focusIdx === 0 ? 'focused' : ''}"
+             data-focusable data-menu-action="${BACK}">
+          <span class="menu-check menu-back">‹</span> Back
+        </div>
+        ${tracks.map((t, i) => html`
+          <div class="menu-item ${this.focusIdx === i + 1 ? 'focused' : ''} ${t.available === false ? 'unavailable' : ''}"
+               data-focusable data-menu-action="${PICK_AUDIO}" data-track-index="${t.index}">
+            <span class="menu-check">${t.active ? '✓' : ''}</span>
+            <span class="menu-track-label">${t.label}</span>
+          </div>
+        `)}
       </div>
     `);
   }
@@ -137,15 +230,15 @@ export class PlayerMenu {
     const el = this.el;
     if (!el) return;
 
-    // Click selects an item
+    // Click selects a row
     el.addEventListener('click', (e: MouseEvent) => {
       const btn = (e.target as HTMLElement).closest<HTMLElement>('[data-menu-action]');
-      if (btn) this.activate(btn.dataset.menuAction as Action);
+      if (btn) this.selectItem(btn);
     });
 
     // Hover moves focus
     el.addEventListener('mouseover', (e: MouseEvent) => {
-      const btn = (e.target as HTMLElement).closest<HTMLElement>('[data-menu-action]');
+      const btn = (e.target as HTMLElement).closest<HTMLElement>('.menu-item');
       if (btn) {
         const items = el.querySelectorAll<HTMLElement>('.menu-item');
         items.forEach((item, i) => {

--- a/src/components/player.ts
+++ b/src/components/player.ts
@@ -1,5 +1,8 @@
-import type { Action, Channel, CatchupInfo } from '../types';
+import type { Action, Channel, CatchupInfo, AudioTrackOption, AudioOption, AudioPref, ManifestAudio } from '../types';
 import { $, show, hide, html, Safe } from '../utils/dom';
+import { channelKey } from '../utils/channel';
+import { fetchText } from '../utils/fetch-helper';
+import { audioLabel, hlsAudioOptions, nativeAudioOptions, chooseAudioIndex, isPrefMatch, parseAudioRenditions, mergeManifestNames } from '../utils/audio-tracks';
 import { PlaylistService } from '../services/playlist-service';
 import { EpgService } from '../services/epg-service';
 import { StorageService } from '../services/storage-service';
@@ -7,6 +10,7 @@ import { CONFIG } from '../config';
 import { formatTime, formatPosition, formatDuration, getProgress } from '../utils/time';
 import { getLenientLoaders } from '../utils/hls-stable-loader';
 import { createLogger } from '../utils/logger';
+import { showToast } from './toast';
 
 const log = createLogger('Player');
 
@@ -34,6 +38,8 @@ export class Player {
   private wasPlayingBeforeHide = false;
   private loadToken = 0;
   private hlsRecoveries = 0; // fatal hls.js errors recovered since the last good fragment
+  private manifestAudio: ManifestAudio[] = []; // real track names parsed from the HLS master (webOS)
+  private manifestSeq = 0;
   constructor(container: HTMLElement, onBack: () => void) {
     this.container = container;
     this.onBack = onBack;
@@ -80,8 +86,12 @@ export class Player {
 
   private bindVideoEvents(el: HTMLVideoElement): void {
     el.addEventListener('error', () => this.onError());
-    el.addEventListener('loadedmetadata', () =>
-      log.info('loadedmetadata', el.videoWidth + 'x' + el.videoHeight, '| duration:', el.duration));
+    el.addEventListener('loadedmetadata', () => {
+      log.info('loadedmetadata', el.videoWidth + 'x' + el.videoHeight, '| duration:', el.duration);
+      this.applyNativeAudioSelection();
+    });
+    // Some platforms populate audioTracks asynchronously, after loadedmetadata.
+    el.audioTracks?.addEventListener?.('addtrack', () => this.applyNativeAudioSelection());
     el.addEventListener('playing', () => log.info('playing'));
     el.addEventListener('waiting', () => log.debug('waiting (buffering)'));
     el.addEventListener('stalled', () => log.warn('stalled'));
@@ -197,6 +207,7 @@ export class Player {
 
   private loadStream(url: string, extras: Record<string, string> | null): void {
     if (!this.videoEl) return;
+    this.manifestAudio = [];
 
     if (this.hls) {
       this.hls.destroy();
@@ -216,6 +227,9 @@ export class Player {
     if (isWebOS) {
       const mime = isFlvUrl ? 'video/x-flv' : isTsUrl ? 'video/mp2t' : 'application/vnd.apple.mpegurl';
       log.info('loadStream url=', url, '| webOS native | catchup:', !!this.catchupInfo, '| MIME', mime);
+      // HLS only: read the master's EXT-X-MEDIA audio names — native audioTracks
+      // expose them with empty name/language on webOS.
+      if (!isTsUrl && !isFlvUrl) void this.loadManifestAudio(url, ++this.manifestSeq);
       this.playNative(url, mime);
       return;
     }
@@ -306,6 +320,9 @@ export class Player {
       this.hls = new Hls(hlsConfig);
       this.hls.loadSource(url);
       this.hls.attachMedia(this.videoEl);
+      // The audio track list isn't ready at MANIFEST_PARSED — hls.js fills it
+      // and fires AUDIO_TRACKS_UPDATED separately, so apply the saved pick there.
+      this.hls.on(Hls.Events.AUDIO_TRACKS_UPDATED, () => this.applyHlsAudioSelection());
       this.hls.on(Hls.Events.MANIFEST_PARSED, () => {
         log.info('hls.js MANIFEST_PARSED — starting playback');
         this.videoEl?.play().catch(e => log.warn('hls play() rejected:', e));
@@ -562,6 +579,120 @@ export class Player {
 
   getCurrentIndex(): number {
     return this.currentIndex;
+  }
+
+  /**
+   * Normalized audio renditions of the active stream — from hls.js in the desktop
+   * preview, or the native `HTMLMediaElement.audioTracks` on webOS (whose alternate
+   * tracks come back empty-named, so real labels are overlaid from the parsed
+   * manifest — see `loadManifestAudio`).
+   */
+  private audioOptions(): AudioOption[] {
+    if (this.hls) return hlsAudioOptions(this.hls.audioTracks || [], this.hls.audioTrack);
+    const list = this.videoEl?.audioTracks;
+    if (!list) return [];
+    return mergeManifestNames(nativeAudioOptions(list), this.manifestAudio);
+  }
+
+  // Fetch the HLS master and parse its audio-rendition names so the picker,
+  // toast and per-channel memory show real labels instead of "Audio 2". Native
+  // audioTracks carry no usable name/language on webOS, so this is the only
+  // source. Re-applies a saved pick once names are known; degrades to generic
+  // labels on a fetch/parse failure.
+  private async loadManifestAudio(url: string, seq: number): Promise<void> {
+    try {
+      const renditions = parseAudioRenditions(await fetchText(url));
+      if (seq !== this.manifestSeq || renditions.length < 2) return;
+      this.manifestAudio = renditions;
+      log.info('manifest audio:', renditions.map(r => r.name || r.lang || '?').join(', '));
+      this.applyNativeAudioSelection();
+    } catch (e) {
+      log.warn('manifest audio fetch failed:', e);
+    }
+  }
+
+  // Picker-facing options. When webOS collapses same-language renditions (the
+  // native list is shorter than the manifest), surface every manifest rendition
+  // but mark the hidden ones unavailable — the TV can't switch to them, so the
+  // picker greys them rather than pretending. `available` assumes the manifest
+  // lists the native-exposed renditions first (default / first-per-language).
+  private displayAudioOptions(): Array<AudioOption & { available: boolean }> {
+    const opts = this.audioOptions();
+    if (this.manifestAudio.length > opts.length) {
+      return this.manifestAudio.map((m, i) => ({
+        index: i, name: m.name, lang: m.lang, isDefault: m.isDefault,
+        active: m.isDefault, available: i < opts.length,
+      }));
+    }
+    return opts.map(o => ({ ...o, available: true }));
+  }
+
+  /** Audio tracks for the picker. Labels prefer name, then language, then a position. */
+  getAudioTracks(): AudioTrackOption[] {
+    return this.displayAudioOptions().map(o => ({
+      index: o.index, label: audioLabel(o), active: o.active, available: o.available,
+    }));
+  }
+
+  /** Switch the active audio track and remember it for this channel. No-op for a
+   *  greyed (unavailable) track — webOS can't switch to a collapsed rendition. */
+  selectAudioTrack(index: number): void {
+    const opt = this.displayAudioOptions().find(o => o.index === index);
+    if (!opt || !opt.available) return;
+    if (this.hls) {
+      if (index >= 0 && index < (this.hls.audioTracks?.length || 0)) this.hls.audioTrack = index;
+    } else {
+      const list = this.videoEl?.audioTracks;
+      if (!list || index < 0 || index >= list.length) return;
+      for (let i = 0; i < list.length; i++) list[i].enabled = (i === index);
+    }
+    this.rememberAudio(opt);
+    showToast(`Switching audio track to ${audioLabel(opt)}`);
+  }
+
+  private audioPrefKey(): string {
+    return this.currentChannel ? channelKey(this.currentChannel) : '';
+  }
+
+  private rememberAudio(opt: AudioOption): void {
+    const key = this.audioPrefKey();
+    if (key) StorageService.setAudioPref(key, { name: opt.name, lang: opt.lang });
+    log.info('audio: user picked', opt.index, audioLabel(opt), key ? '— saved to storage' : '(no channel key, not saved)');
+  }
+
+  // Report the storage read and the resolved track on every tune-in — even when
+  // no switch is needed (the chosen track is already active) — so the default
+  // pick and the pref lookup are both visible in the log.
+  private logAudioChoice(path: string, options: AudioOption[], pref: AudioPref | null, idx: number): void {
+    const opt = options.find(o => o.index === idx);
+    const label = opt ? audioLabel(opt) : `Audio ${idx + 1}`;
+    log.info(`audio: ${path} | tracks:`, options.length,
+      '| storage pref:', pref ? (pref.name || pref.lang || '(unnamed)') : 'none',
+      '| using:', idx, label, isPrefMatch(opt, pref) ? '(saved pref)' : '(stream default)');
+  }
+
+  // Re-apply the remembered choice on tune-in; with no saved pick the stream
+  // default stands. hls.js drives its own rendition, so the two paths are split.
+  private applyHlsAudioSelection(): void {
+    if (!this.hls) return;
+    const options = this.audioOptions();
+    if (options.length < 2) return;
+    const pref = StorageService.getAudioPref(this.audioPrefKey());
+    const idx = chooseAudioIndex(options, pref);
+    this.logAudioChoice('hls', options, pref, idx);
+    if (idx >= 0 && idx !== this.hls.audioTrack) this.hls.audioTrack = idx;
+  }
+
+  private applyNativeAudioSelection(): void {
+    if (this.hls) return; // hls.js owns the rendition; videoEl exposes only the active one
+    const list = this.videoEl?.audioTracks;
+    if (!list || list.length < 2) return;
+    const options = this.audioOptions();
+    const pref = StorageService.getAudioPref(this.audioPrefKey());
+    const idx = chooseAudioIndex(options, pref);
+    this.logAudioChoice('native', options, pref, idx);
+    if (idx < 0 || list[idx].enabled) return; // already active — don't disturb playback
+    for (let i = 0; i < list.length; i++) list[i].enabled = (i === idx);
   }
 
   handleAction(action: Action): void {

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,3 +1,25 @@
 declare const __APP_ID__: string;
 declare const __APP_VERSION__: string;
 declare const __SERVICE_ID__: string;
+
+// TypeScript's DOM lib dropped the multi-track interfaces (they're disabled by
+// default in most browsers), but LG's webOS WebView populates them from the
+// native media pipeline — so declare the subset we use. See
+// docs/audio-track-selection.md.
+interface AudioTrack {
+  enabled: boolean;
+  readonly id: string;
+  readonly kind: string;
+  readonly label: string;
+  readonly language: string;
+}
+
+interface AudioTrackList extends EventTarget {
+  readonly length: number;
+  getTrackById(id: string): AudioTrack | null;
+  [index: number]: AudioTrack;
+}
+
+interface HTMLMediaElement {
+  readonly audioTracks?: AudioTrackList;
+}

--- a/src/services/storage-service.test.ts
+++ b/src/services/storage-service.test.ts
@@ -73,4 +73,31 @@ describe('StorageService', () => {
       expect(StorageService.getFavorites()).toEqual([]);
     });
   });
+
+  describe('audio preferences', () => {
+    it('returns null when no choice is saved for a channel', () => {
+      expect(StorageService.getAudioPref('ch1')).toBeNull();
+    });
+
+    it('remembers a choice per channel without bleeding across channels', () => {
+      StorageService.setAudioPref('ch1', { name: 'Track 1', lang: 'l1' });
+      StorageService.setAudioPref('ch2', { name: 'Track 2', lang: 'l2' });
+      expect(StorageService.getAudioPref('ch1')).toEqual({ name: 'Track 1', lang: 'l1' });
+      expect(StorageService.getAudioPref('ch2')).toEqual({ name: 'Track 2', lang: 'l2' });
+      expect(StorageService.getAudioPref('ch3')).toBeNull();
+    });
+
+    it('persists through localStorage (survives a reload)', () => {
+      StorageService.setAudioPref('ch1', { name: 'Track 2', lang: 'l1' });
+      // A fresh read goes back to localStorage — no in-memory cache.
+      expect(StorageService.getAudioPref('ch1')).toEqual({ name: 'Track 2', lang: 'l1' });
+      expect(localStorage.getItem('iptv_audio_prefs')).toContain('Track 2');
+    });
+
+    it('ignores an empty channel id', () => {
+      StorageService.setAudioPref('', { name: 'Track 1', lang: 'l1' });
+      expect(StorageService.getAudioPref('')).toBeNull();
+      expect(localStorage.getItem('iptv_audio_prefs')).toBeNull();
+    });
+  });
 });

--- a/src/services/storage-service.ts
+++ b/src/services/storage-service.ts
@@ -1,5 +1,5 @@
 import { CONFIG } from '../config';
-import type { Channel, PlaylistEntry, TzMode } from '../types';
+import type { AudioPref, Channel, PlaylistEntry, TzMode } from '../types';
 import { channelKey } from '../utils/channel';
 
 const PREFIX = CONFIG.STORAGE_PREFIX;
@@ -107,6 +107,18 @@ export const StorageService = {
   },
   setAutoPlay(val: boolean): void {
     set('auto_play', val);
+  },
+
+  // Preferred audio track per channel (keyed by channelKey). Absent = follow the stream's default.
+  getAudioPref(channelId: string): AudioPref | null {
+    if (!channelId) return null;
+    return get<Record<string, AudioPref>>('audio_prefs', {})[channelId] ?? null;
+  },
+  setAudioPref(channelId: string, pref: AudioPref): void {
+    if (!channelId) return;
+    const all = get<Record<string, AudioPref>>('audio_prefs', {});
+    all[channelId] = pref;
+    set('audio_prefs', all);
   },
 
   // 'device' = the device's timezone (default), 'feed' = the EPG feed's timezone.

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,39 @@ export interface NumberEvent {
   number: number;
 }
 
+/** A selectable audio track exposed by the active player (the picker's view model). */
+export interface AudioTrackOption {
+  index: number;
+  label: string;
+  active: boolean;
+  /** False = shown but not switchable — a same-language rendition webOS collapsed
+   *  out of the native list. Defaults to switchable when absent. */
+  available?: boolean;
+}
+
+/** Normalized audio rendition, unified across the hls.js list and the native
+ *  HTMLMediaElement.audioTracks list so one selection routine serves both. */
+export interface AudioOption {
+  index: number;
+  name: string;
+  lang: string;
+  isDefault: boolean;
+  active: boolean;
+}
+
+/** A remembered audio-track choice, matched against future streams by name then language. */
+export interface AudioPref {
+  name: string;
+  lang: string;
+}
+
+/** An audio rendition declared in an HLS master playlist (EXT-X-MEDIA:TYPE=AUDIO). */
+export interface ManifestAudio {
+  name: string;
+  lang: string;
+  isDefault: boolean;
+}
+
 export interface ViewHandler {
   handleAction(action: Action, event?: NumberEvent): void;
 }

--- a/src/utils/audio-tracks.test.ts
+++ b/src/utils/audio-tracks.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import type { AudioOption } from '../types';
+import {
+  audioLabel,
+  hlsAudioOptions,
+  nativeAudioOptions,
+  chooseAudioIndex,
+  isPrefMatch,
+  parseAudioRenditions,
+  mergeManifestNames,
+} from './audio-tracks';
+
+const opt = (over: Partial<AudioOption>): AudioOption => ({
+  index: 0, name: '', lang: '', isDefault: false, active: false, ...over,
+});
+
+// Build a native AudioTrackList-like object (the DOM type is absent in node tests).
+const nativeList = (tracks: Array<{ label?: string; language?: string; enabled?: boolean }>): AudioTrackList => {
+  const list: Record<number | string, unknown> = { length: tracks.length };
+  tracks.forEach((t, i) => {
+    list[i] = { label: t.label ?? '', language: t.language ?? '', enabled: !!t.enabled, id: '', kind: '' };
+  });
+  return list as unknown as AudioTrackList;
+};
+
+describe('audioLabel', () => {
+  it('prefers name, then language, then a positional fallback', () => {
+    expect(audioLabel(opt({ index: 0, name: 'Track 1', lang: 'l1' }))).toBe('Track 1');
+    expect(audioLabel(opt({ index: 1, name: '', lang: 'l2' }))).toBe('l2');
+    expect(audioLabel(opt({ index: 2, name: '', lang: '' }))).toBe('Audio 3');
+  });
+});
+
+describe('hlsAudioOptions', () => {
+  it('normalizes name/lang/default and marks the current index active', () => {
+    const opts = hlsAudioOptions(
+      [{ name: 'Track 1', lang: 'l1', default: true }, { name: 'Track 2', lang: 'l2' }],
+      1,
+    );
+    expect(opts).toEqual([
+      { index: 0, name: 'Track 1', lang: 'l1', isDefault: true, active: false },
+      { index: 1, name: 'Track 2', lang: 'l2', isDefault: false, active: true },
+    ]);
+  });
+
+  it('coerces missing fields to empty strings / false', () => {
+    expect(hlsAudioOptions([{}], -1)).toEqual([
+      { index: 0, name: '', lang: '', isDefault: false, active: false },
+    ]);
+  });
+});
+
+describe('nativeAudioOptions', () => {
+  it('maps label→name, language→lang, enabled→isDefault+active', () => {
+    const opts = nativeAudioOptions(nativeList([
+      { label: 'Track 1', language: 'l1', enabled: true },
+      { label: 'Track 2', language: 'l2', enabled: false },
+    ]));
+    expect(opts).toEqual([
+      { index: 0, name: 'Track 1', lang: 'l1', isDefault: true, active: true },
+      { index: 1, name: 'Track 2', lang: 'l2', isDefault: false, active: false },
+    ]);
+  });
+
+  it("treats 'und' language as empty", () => {
+    expect(nativeAudioOptions(nativeList([{ label: 'Track 1', language: 'und' }]))[0].lang).toBe('');
+  });
+});
+
+describe('chooseAudioIndex', () => {
+  const opts = [
+    opt({ index: 0, name: 'Track 1', lang: 'l1', isDefault: true }),
+    opt({ index: 1, name: 'Track 2', lang: 'l2' }),
+    opt({ index: 2, name: 'Track 3', lang: 'l3' }),
+  ];
+
+  it('returns -1 for no options', () => {
+    expect(chooseAudioIndex([], null)).toBe(-1);
+  });
+
+  it('falls back to the default track when no pref is saved', () => {
+    expect(chooseAudioIndex(opts, null)).toBe(0);
+  });
+
+  it('falls back to the first track when nothing is marked default', () => {
+    const noDefault = opts.map(o => ({ ...o, isDefault: false }));
+    expect(chooseAudioIndex(noDefault, null)).toBe(0);
+  });
+
+  it('matches a saved pref by name, case-insensitively', () => {
+    expect(chooseAudioIndex(opts, { name: 'track 2', lang: '' })).toBe(1);
+  });
+
+  it('matches by language when the name does not match', () => {
+    expect(chooseAudioIndex(opts, { name: 'gone', lang: 'l3' })).toBe(2);
+  });
+
+  it('prefers a name match over a language match', () => {
+    const collide = [
+      opt({ index: 0, name: 'Track 1', lang: 'shared' }),
+      opt({ index: 1, name: 'Track 2', lang: 'shared' }),
+    ];
+    expect(chooseAudioIndex(collide, { name: 'Track 2', lang: 'shared' })).toBe(1);
+  });
+
+  it('falls back to the default when the pref matches nothing', () => {
+    expect(chooseAudioIndex(opts, { name: 'gone', lang: 'gone' })).toBe(0);
+  });
+});
+
+describe('isPrefMatch', () => {
+  const o = opt({ index: 1, name: 'Track 2', lang: 'l2' });
+
+  it('is false without a pref or option', () => {
+    expect(isPrefMatch(o, null)).toBe(false);
+    expect(isPrefMatch(undefined, { name: 'Track 2', lang: 'l2' })).toBe(false);
+  });
+
+  it('matches by name or language, case-insensitively', () => {
+    expect(isPrefMatch(o, { name: 'track 2', lang: '' })).toBe(true);
+    expect(isPrefMatch(o, { name: '', lang: 'L2' })).toBe(true);
+  });
+
+  it('does not count two empty fields as a match', () => {
+    expect(isPrefMatch(opt({ index: 0, name: '', lang: '' }), { name: '', lang: '' })).toBe(false);
+  });
+});
+
+describe('parseAudioRenditions', () => {
+  it('parses TYPE=AUDIO renditions in order with name/lang/default', () => {
+    const m = [
+      '#EXTM3U',
+      '#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="a",NAME="Track 1",LANGUAGE="l1",DEFAULT=YES,AUTOSELECT=YES',
+      '#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="a",NAME="Track 2",LANGUAGE="l2",DEFAULT=NO',
+      '#EXT-X-STREAM-INF:BANDWIDTH=1,AUDIO="a"',
+      'v1.m3u8',
+    ].join('\n');
+    expect(parseAudioRenditions(m)).toEqual([
+      { name: 'Track 1', lang: 'l1', isDefault: true },
+      { name: 'Track 2', lang: 'l2', isDefault: false },
+    ]);
+  });
+
+  it('ignores non-audio media and dedupes renditions repeated per quality tier', () => {
+    const m = [
+      '#EXT-X-MEDIA:TYPE=SUBTITLES,NAME="Track 9",LANGUAGE="l9"',
+      '#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="lo",NAME="Track 1",LANGUAGE="l1"',
+      '#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="lo",NAME="Track 2",LANGUAGE="l2"',
+      '#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="hi",NAME="Track 1",LANGUAGE="l1"',
+      '#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="hi",NAME="Track 2",LANGUAGE="l2"',
+    ].join('\n');
+    expect(parseAudioRenditions(m).map(r => r.name)).toEqual(['Track 1', 'Track 2']);
+  });
+
+  it('anchors attributes so LANGUAGE does not match ASSOC-LANGUAGE', () => {
+    const m = '#EXT-X-MEDIA:TYPE=AUDIO,NAME="Track 1",ASSOC-LANGUAGE="zz",LANGUAGE="l1"';
+    expect(parseAudioRenditions(m)[0].lang).toBe('l1');
+  });
+
+  it('returns [] when there are no audio renditions', () => {
+    expect(parseAudioRenditions('#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1\nv.m3u8')).toEqual([]);
+  });
+});
+
+describe('mergeManifestNames', () => {
+  const opts = [
+    opt({ index: 0, name: '', lang: 'l1', isDefault: true, active: true }),
+    opt({ index: 1, name: '', lang: '' }),
+  ];
+
+  it('overlays names/langs by index when counts match', () => {
+    const merged = mergeManifestNames(opts, [
+      { name: 'Track 1', lang: 'l1', isDefault: true },
+      { name: 'Track 2', lang: 'l2', isDefault: false },
+    ]);
+    expect(merged.map(o => o.name)).toEqual(['Track 1', 'Track 2']);
+    expect(merged[1].lang).toBe('l2');
+    expect(merged[0].active).toBe(true); // native live state preserved
+  });
+
+  it('leaves options untouched when counts differ (collapsed native list)', () => {
+    expect(mergeManifestNames(opts, [{ name: 'Track 1', lang: 'l1', isDefault: true }])).toBe(opts);
+  });
+
+  it('keeps the native value when a manifest field is empty', () => {
+    const merged = mergeManifestNames(opts, [
+      { name: '', lang: '', isDefault: false },
+      { name: 'Track 2', lang: '', isDefault: false },
+    ]);
+    expect(merged[0].lang).toBe('l1'); // native lang kept
+  });
+});

--- a/src/utils/audio-tracks.ts
+++ b/src/utils/audio-tracks.ts
@@ -1,0 +1,85 @@
+import type { AudioOption, AudioPref, ManifestAudio } from '../types';
+
+// The hls.js audio-track fields we read, structural to avoid an hls.js type dep.
+export interface HlsAudioTrackLike {
+  name?: string;
+  lang?: string;
+  default?: boolean;
+}
+
+/** Display label for a rendition: its name, then language, then a positional fallback. */
+export function audioLabel(opt: AudioOption): string {
+  return opt.name || opt.lang || `Audio ${opt.index + 1}`;
+}
+
+/** Normalize hls.js renditions. `currentIdx` is hls.audioTrack (the active one). */
+export function hlsAudioOptions(tracks: readonly HlsAudioTrackLike[], currentIdx: number): AudioOption[] {
+  return tracks.map((t, index) => ({
+    index,
+    name: t.name || '',
+    lang: t.lang || '',
+    isDefault: !!t.default, // hls.js parses the manifest DEFAULT flag
+    active: index === currentIdx,
+  }));
+}
+
+/** Normalize the native HTMLMediaElement.audioTracks list. */
+export function nativeAudioOptions(list: AudioTrackList): AudioOption[] {
+  return Array.from({ length: list.length }, (_, i) => {
+    const t = list[i];
+    const lang = t.language && t.language !== 'und' ? t.language : '';
+    // The native API exposes no manifest DEFAULT; the UA's pick stands in.
+    return { index: i, name: t.label || '', lang, isDefault: t.enabled, active: t.enabled };
+  });
+}
+
+/** Pick a track index for `options`, preferring `pref` (name then language), else the default. */
+export function chooseAudioIndex(options: AudioOption[], pref: AudioPref | null): number {
+  if (!options.length) return -1;
+  if (pref) {
+    const byName = pref.name && options.find(o => o.name.toLowerCase() === pref.name.toLowerCase());
+    if (byName) return byName.index;
+    const byLang = pref.lang && options.find(o => o.lang.toLowerCase() === pref.lang.toLowerCase());
+    if (byLang) return byLang.index;
+  }
+  return (options.find(o => o.isDefault) ?? options[0]).index;
+}
+
+/** Whether `pref` actually matched `opt` (vs. falling back to the stream default). */
+export function isPrefMatch(opt: AudioOption | undefined, pref: AudioPref | null): boolean {
+  return !!pref && !!opt
+    && ((!!pref.name && opt.name.toLowerCase() === pref.name.toLowerCase())
+      || (!!pref.lang && opt.lang.toLowerCase() === pref.lang.toLowerCase()));
+}
+
+// Parse the EXT-X-MEDIA:TYPE=AUDIO renditions from an HLS master playlist, in
+// declaration order, deduped by name+language (some manifests repeat the audio
+// group per quality tier). webOS native exposes these tracks with empty
+// name/language, so the manifest is the only source of real names on-device.
+export function parseAudioRenditions(manifest: string): ManifestAudio[] {
+  const out: ManifestAudio[] = [];
+  const seen = new Set<string>();
+  for (const line of manifest.split(/\r?\n/)) {
+    if (!line.startsWith('#EXT-X-MEDIA:') || !/TYPE=AUDIO(?:,|$)/.test(line)) continue;
+    // Anchor each attribute on a `:`/`,` so LANGUAGE doesn't match ASSOC-LANGUAGE.
+    const attr = (k: string): string => line.match(new RegExp(`[:,]${k}="([^"]*)"`))?.[1] ?? '';
+    const name = attr('NAME');
+    const lang = attr('LANGUAGE');
+    const key = JSON.stringify([name, lang]);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ name, lang, isDefault: /[:,]DEFAULT=YES(?:,|$)/.test(line) });
+  }
+  return out;
+}
+
+/** Overlay manifest names/languages onto native track options, by index. Only
+ *  applies when the counts line up, so a collapsed native list isn't mislabelled. */
+export function mergeManifestNames(opts: AudioOption[], manifest: ManifestAudio[]): AudioOption[] {
+  if (!manifest.length || manifest.length !== opts.length) return opts;
+  return opts.map((o, i) => ({
+    ...o,
+    name: manifest[i].name || o.name,
+    lang: manifest[i].lang || o.lang,
+  }));
+}


### PR DESCRIPTION
A player-menu "Audio Track" row opens an in-place picker to switch a stream's audio renditions; the choice is remembered per channel and re-applied on the next tune-in (matched by name, then language, else the manifest DEFAULT).

- Native webOS path switches via HTML5 audioTracks[i].enabled — the only safe API. com.webos.media/selectTrack is reachable but decode-errors on a track the pipeline never demuxed, so it's avoided. Desktop preview switches with hls.js (hls.audioTrack).
- Real names come from parsing the master EXT-X-MEDIA: webOS exposes the alternate tracks with empty name/language; the names also key the per-channel memory.
- webOS collapses same-language renditions to one native track; the others are shown but greyed (not switchable) so the menu never lies.

Pure helpers (parse/normalize/choose) live in src/utils/audio-tracks.ts, unit-tested; docs/audio-track-selection.md documents the on-device webOS behaviour.

See #4 