### PR TITLE
Fix endless MPEG-TS manifest probes

### DIFF
--- a/src/components/player.test.ts
+++ b/src/components/player.test.ts
@@ -372,6 +372,30 @@ describe('Player live playback', () => {
     expect(player.canSeek()).toBe(false);
     expect(container.querySelector('[data-seekbar]')).toBeNull();
   });
+
+  it('aborts the previous manifest probe when a new one starts', async () => {
+    const signals: AbortSignal[] = [];
+    vi.stubGlobal('fetch', vi.fn((_url: string, opts: RequestInit) => {
+      signals.push(opts.signal as AbortSignal);
+      return new Promise<Response>((_resolve, reject) => {
+        opts.signal?.addEventListener('abort', () =>
+          reject(new DOMException('Aborted', 'AbortError')));
+      });
+    }));
+    const internals = player as unknown as {
+      loadManifestTracks(url: string, seq: number): Promise<void>;
+    };
+
+    const first = internals.loadManifestTracks('http://host/a', 0);
+    await Promise.resolve();
+    const second = internals.loadManifestTracks('http://host/b', 0);
+    await Promise.resolve();
+
+    expect(signals[0].aborted).toBe(true);
+    expect(signals[1].aborted).toBe(false);
+    player.stop();
+    await Promise.all([first, second]);
+  });
 });
 
 describe('Player Recently Watched recording', () => {

--- a/src/components/player.ts
+++ b/src/components/player.ts
@@ -5,7 +5,7 @@ import { $, show, hide, html, raw, Safe } from '../utils/dom';
 import { channelKey } from '../utils/channel';
 import { morph } from '../utils/morph';
 import { dvrWindow, dvrState, type DvrWindow, type DvrState } from '../utils/dvr';
-import { fetchText } from '../utils/fetch-helper';
+import { fetchLimitedText } from '../utils/fetch-helper';
 import { audioLabel, hlsAudioOptions, nativeAudioOptions, chooseAudioIndex, isPrefMatch, parseAudioRenditions, mergeManifestNames } from '../utils/audio-tracks';
 import { subtitleLabel, hlsSubtitleOptions, manifestSubtitleOptions, nativeSubtitleOptions, chooseSubtitleIndex, isSubtitlePrefMatch, parseSubtitleRenditions, parseClosedCaptions, closedCaptionLabel, clampSubtitleOffset, formatSubtitleOffset, shiftForeignTrack } from '../utils/subtitle-tracks';
 import { PlaylistService } from '../services/playlist-service';
@@ -104,6 +104,7 @@ export class Player {
   private manifestVariants: StreamVariant[] = []; // HLS master variants for best-effort codec readout
   private vodInfo: MediaInfo | null = null; // container-header stream info for the active VOD (codec/fps/HDR)
   private manifestSeq = 0;
+  private manifestController: AbortController | null = null;
   private subs = new HlsSubtitles(); // self-rendered subtitles on the webOS native path
   private vodSubs = new VodSubtitles(); // sidecar SRT/WebVTT tracks for VOD (Xtream)
   private assSubs = new AssSubtitles(); // sidecar ASS/SSA subtitles for VOD, drawn by assjs
@@ -245,6 +246,7 @@ export class Player {
       }
       this.stallWatchdog.stop();
       this.subs.stop();
+      this.cancelManifestTracks();
       if (this.hls) {
         this.hls.destroy();
         this.hls = null;
@@ -748,6 +750,7 @@ export class Player {
     this.saveCatchupProgress(); // save before the video element is torn down
     this.stallWatchdog.stop();
     this.subs.stop();
+    this.cancelManifestTracks();
     this.vodSubs.clear();
     this.assSubs.destroy();
     if (this.hls) {
@@ -814,6 +817,7 @@ export class Player {
 
   private loadStream(url: string, extras: Record<string, string> | null, opts?: { direct?: boolean }): void {
     if (!this.videoEl) return;
+    this.cancelManifestTracks();
     this.manifestAudio = [];
     this.manifestSubtitles = [];
     this.manifestClosedCaptions = [];
@@ -850,7 +854,7 @@ export class Player {
       log.info('loadStream url=', url, '| webOS native | catchup:', !!this.catchupInfo, '| MIME', mime);
       // HLS only: read the master's EXT-X-MEDIA audio/subtitle names — native
       // audio/text tracks expose them with empty name/language on webOS.
-      if (!isTsUrl && !isFlvUrl) void this.loadManifestTracks(url, ++this.manifestSeq);
+      if (!isTsUrl && !isFlvUrl) void this.loadManifestTracks(url, this.manifestSeq);
       this.playNative(url, mime);
       return;
     }
@@ -1539,8 +1543,17 @@ export class Player {
   // name/language on webOS, so this is the only source. Re-applies the saved
   // picks once names are known; degrades to generic labels on a fetch failure.
   private async loadManifestTracks(url: string, seq: number): Promise<void> {
+    const controller = new AbortController();
+    this.manifestController?.abort();
+    this.manifestController = controller;
     try {
-      const text = await fetchText(url);
+      const text = await fetchLimitedText(
+        url,
+        CONFIG.PLAYER.MANIFEST_MAX_BYTES,
+        CONFIG.PLAYER.MANIFEST_TIMEOUT,
+        controller.signal,
+        '#EXTM3U',
+      );
       if (seq !== this.manifestSeq) return;
       const audio = parseAudioRenditions(text);
       if (audio.length >= 2) {
@@ -1569,8 +1582,17 @@ export class Player {
         log.info('manifest variants:', variants.length);
       }
     } catch (e) {
+      if (controller.signal.aborted) return;
       log.warn('manifest tracks fetch failed:', e);
+    } finally {
+      if (this.manifestController === controller) this.manifestController = null;
     }
+  }
+
+  private cancelManifestTracks(): void {
+    this.manifestSeq++;
+    this.manifestController?.abort();
+    this.manifestController = null;
   }
 
   // Picker-facing options. When webOS collapses same-language renditions (the

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,8 @@ export const CONFIG = {
   PLAYER: {
     OSD_TIMEOUT: 5000,
     BUFFER_LENGTH: 30,
+    MANIFEST_TIMEOUT: 5000,
+    MANIFEST_MAX_BYTES: 256 * 1024,
     CHANNEL_NUMBER_TIMEOUT: 2000,
     SEEK_STEP: 30,              // seconds per Left/Right press while seeking catch-up or live DVR
     HLS_MAX_RECOVERIES: 3,      // bounded hls.js fatal-error retries before giving up → next channel

--- a/src/utils/fetch-helper.test.ts
+++ b/src/utils/fetch-helper.test.ts
@@ -1,6 +1,6 @@
 import { gzipSync, strToU8 } from 'fflate';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { fetchMaybeGzipText, fetchText, fetchWithTimeout, fetchWithRetry } from './fetch-helper';
+import { fetchLimitedText, fetchMaybeGzipText, fetchText, fetchWithTimeout, fetchWithRetry } from './fetch-helper';
 
 function okResponse(body = 'body'): Response {
   return {
@@ -50,6 +50,67 @@ describe('fetchText / fetchWithTimeout', () => {
     const p = fetchWithTimeout('http://x', {}, 5000);
     const assertion = expect(p).rejects.toThrow('Aborted');
     await vi.advanceTimersByTimeAsync(5000);
+    await assertion;
+  });
+
+  it('keeps the fetchText timeout active while reading the response body', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (_url: string, opts: RequestInit) => ({
+      ok: true,
+      text: () => new Promise<string>((_resolve, reject) => {
+        opts.signal?.addEventListener('abort', () =>
+          reject(new DOMException('Aborted', 'AbortError')));
+      }),
+    } as unknown as Response)));
+    const p = fetchText('http://x', 5000);
+    const assertion = expect(p).rejects.toThrow('Aborted');
+    await vi.advanceTimersByTimeAsync(5000);
+    await assertion;
+  });
+});
+
+describe('fetchLimitedText', () => {
+  it('cancels an endless response after reaching the byte limit', async () => {
+    const cancel = vi.fn(async () => {});
+    const read = vi.fn()
+      .mockResolvedValueOnce({ done: false, value: new Uint8Array(5) })
+      .mockResolvedValueOnce({ done: false, value: new Uint8Array(5) });
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      body: { getReader: () => ({ read, cancel }) },
+    } as unknown as Response)));
+
+    await expect(fetchLimitedText('http://x', 8, 5000)).rejects.toThrow('exceeds 8 bytes');
+    expect(cancel).toHaveBeenCalled();
+  });
+
+  it('cancels binary MPEG-TS data as soon as it cannot be an HLS manifest', async () => {
+    const cancel = vi.fn(async () => {});
+    const read = vi.fn()
+      .mockResolvedValueOnce({ done: false, value: new Uint8Array([0x47, 0x40, 0x00, 0x10, 0x00, 0x00, 0x01]) })
+      .mockResolvedValueOnce({ done: false, value: new Uint8Array(1024) });
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      body: { getReader: () => ({ read, cancel }) },
+    } as unknown as Response)));
+
+    await expect(fetchLimitedText('http://host/a', 256 * 1024, 5000, undefined, '#EXTM3U'))
+      .rejects.toThrow('does not begin with #EXTM3U');
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(cancel).toHaveBeenCalled();
+  });
+
+  it('honors an external abort while reading the body', async () => {
+    const controller = new AbortController();
+    vi.stubGlobal('fetch', vi.fn((_url: string, opts: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        opts.signal?.addEventListener('abort', () =>
+          reject(new DOMException('Aborted', 'AbortError')));
+      }),
+    ));
+
+    const p = fetchLimitedText('http://x', 1024, 5000, controller.signal);
+    const assertion = expect(p).rejects.toThrow('Aborted');
+    controller.abort();
     await assertion;
   });
 });

--- a/src/utils/fetch-helper.ts
+++ b/src/utils/fetch-helper.ts
@@ -16,8 +16,81 @@ export async function fetchWithTimeout(
 }
 
 export async function fetchText(url: string, timeout = 30000): Promise<string> {
-  const response = await fetchWithTimeout(url, {}, timeout);
-  return response.text();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    return await response.text();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function fetchLimitedText(
+  url: string,
+  maxBytes: number,
+  timeout: number,
+  signal?: AbortSignal,
+  requiredPrefix?: string,
+): Promise<string> {
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  const timer = setTimeout(abort, timeout);
+  if (signal?.aborted) abort();
+  else signal?.addEventListener('abort', abort);
+
+  let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  let complete = false;
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    reader = response.body?.getReader() ?? null;
+    if (!reader) {
+      const bytes = new Uint8Array(await response.arrayBuffer());
+      if (bytes.length > maxBytes) throw new Error(`Response exceeds ${maxBytes} bytes`);
+      return new TextDecoder().decode(bytes);
+    }
+
+    const chunks: Uint8Array[] = [];
+    let length = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) { complete = true; break; }
+      if (!value?.length) continue;
+      length += value.length;
+      if (length > maxBytes) throw new Error(`Response exceeds ${maxBytes} bytes`);
+      chunks.push(value);
+      if (requiredPrefix && length >= requiredPrefix.length) {
+        let offset = 0;
+        for (const chunk of chunks) {
+          for (let i = 0; i < chunk.length && offset < requiredPrefix.length; i++, offset++) {
+            if (chunk[i] !== requiredPrefix.charCodeAt(offset)) {
+              throw new Error(`Response does not begin with ${requiredPrefix}`);
+            }
+          }
+          if (offset === requiredPrefix.length) break;
+        }
+      }
+    }
+
+    const bytes = new Uint8Array(length);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.length;
+    }
+    const text = new TextDecoder().decode(bytes);
+    if (requiredPrefix && !text.startsWith(requiredPrefix)) {
+      throw new Error(`Response does not begin with ${requiredPrefix}`);
+    }
+    return text;
+  } finally {
+    if (reader && !complete) void reader.cancel().catch(() => {});
+    clearTimeout(timer);
+    signal?.removeEventListener('abort', abort);
+  }
 }
 
 export async function fetchMaybeGzipText(url: string, timeout = 30000): Promise<string> {


### PR DESCRIPTION
Extensionless continuous MPEG-TS streams were treated as HLS manifests, leaving one fetch alive after every channel switch and eventually saturating renderer CPU.

- Abort stale manifest reads when playback changes.
- Reject non-HLS prefixes and cap manifest responses at 256 KiB.
- Keep timeouts active while consuming response bodies.
- Cover prefix sniffing, limits, timeouts, and cancellation.

See #20 