### PR TITLE
Fix: Add neighborChannel handling in Sidebar and Player for CH+/CH− scope

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -1,6 +1,6 @@
 {
   "id": "com.lennylxx.iptv",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "vendor": "lennylxx",
   "type": "web",
   "main": "index.html",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1235,9 +1235,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1255,9 +1252,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1275,9 +1269,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1295,9 +1286,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1315,9 +1303,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1335,9 +1320,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3541,9 +3523,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3565,9 +3544,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3589,9 +3565,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3613,9 +3586,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webos-iptv-player",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "private": true,
   "license": "Apache-2.0",
   "comment:browserslist": "The gate's target = the FLOOR of the supported fleet: webOS 5 = Chromium 68. Drives stylelint/doiuse (CSS) and eslint-plugin-compat (JS APIs); esbuild uses its own 'chrome68' syntax target. A static gate can only check the floor (eslint-plugin-compat flags not-yet-added APIs, NOT ones removed by newer engines), so forward-compat on newer TVs (up to webOS 10.3 / Chromium 120) is left to the Playwright e2e, which runs on a current Chromium.",

--- a/src/app.ts
+++ b/src/app.ts
@@ -73,7 +73,7 @@ class App {
 
     this.channelList = new ChannelList(
       this.views.channels,
-      (idx, catchup) => this.playChannel(idx, catchup),
+      (idx, catchup) => this.playChannel(idx, catchup, 'channels'),
       () => this.player.syncCurrentIndex(),
     );
     this.player = new Player(this.views.player, () => {
@@ -81,7 +81,7 @@ class App {
       this.showView('channels');
     }, (idx, catchupStart) => this.channelList.setPlaying(idx, catchupStart),
     () => !this.sidebar.visible && !this.menu.visible);
-    this.epgGrid = new EpgGrid(this.views.epg, (idx, catchup) => this.playChannel(idx, catchup));
+    this.epgGrid = new EpgGrid(this.views.epg, (idx, catchup) => this.playChannel(idx, catchup, 'other'));
     this.settings = new Settings(
       this.views.settings,
       (action) => this.onSettingsSaved(action),
@@ -93,9 +93,10 @@ class App {
     this.sidebar = new Sidebar(
       this.views.player,
       () => this.player.getCurrentIndex(),
-      (idx, catchup) => this.playChannel(idx, catchup),
+      (idx, catchup) => this.playChannel(idx, catchup, 'sidebar'),
       () => this.player.getCurrentCatchupStart(),
     );
+    this.player.setNeighborResolver((delta) => this.sidebar.neighborChannel(delta));
     this.menu = new PlayerMenu(
       this.views.player,
       () => this.player.getCurrentChannel(),
@@ -139,7 +140,7 @@ class App {
     this.search = new Search(this.views.search, {
       onRevealTabBar: () => this.tabBar.focus(),
       onBack: () => this.goLive(),
-      onPlayChannel: (idx, catchup) => { this.tabBar.blur(); this.playChannel(idx, catchup); },
+      onPlayChannel: (idx, catchup) => { this.tabBar.blur(); this.playChannel(idx, catchup, 'other'); },
       onOpenMovie: (account, vod) => {
         this.tabBar.blur();
         this.showView('movies');
@@ -675,7 +676,22 @@ class App {
     }
   }
 
-  private playChannel(index: number, catchup?: CatchupInfo): void {
+  private playChannel(
+    index: number,
+    catchup?: CatchupInfo,
+    from: 'channels' | 'sidebar' | 'other' = 'other',
+  ): void {
+    // CH+/CH− follow the browse filter the user is in. Sync sidebar ↔ channel
+    // list so the zap scope matches Favorites / the active category.
+    if (from === 'channels') {
+      const loc = this.channelList.getLocation();
+      this.sidebar.setLocation(loc.group, loc.playlist);
+    } else if (from === 'sidebar') {
+      const loc = this.sidebar.getLocation();
+      this.channelList.setLocation(loc.group, loc.playlist);
+    } else {
+      this.sidebar.setLocation('builtin:all', '');
+    }
     this.showView('player');
     this.player.play(index, catchup);
   }

--- a/src/components/channel-list.ts
+++ b/src/components/channel-list.ts
@@ -139,6 +139,16 @@ export class ChannelList {
     return el && this.container.contains(el) ? el : null;
   }
 
+  getLocation(): { group: ChannelGroupId; playlist: string } {
+    return { group: this.currentGroup, playlist: this.currentPlaylist };
+  }
+
+  setLocation(group: ChannelGroupId, playlist = ''): void {
+    if (this.currentGroup === group && this.currentPlaylist === playlist) return;
+    this.currentGroup = group;
+    this.currentPlaylist = playlist;
+  }
+
   render(ensureFocus = true): void {
     const tabs = PlaylistService.playlistTabs;
     // The selected playlist may have just been deleted in settings — fall back to All.

--- a/src/components/player.test.ts
+++ b/src/components/player.test.ts
@@ -1097,6 +1097,18 @@ describe('Player catch-up save/restore lifecycle', () => {
     );
   });
 
+  it('channelUp prefers the group neighbor resolver over the All list', () => {
+    const other = { ...CHANNEL, id: 'c9', name: 'Other', url: 'http://host/play/c9' };
+    playlistMock.channels = [CHANNEL, other, { ...CHANNEL, id: 'c3' }];
+    playlistMock.getByIndex.mockImplementation((i: number) => playlistMock.channels[i]);
+    player.setNeighborResolver((delta) => (delta > 0 ? 2 : 0));
+    player.play(0);
+    player.channelUp();
+    expect(player.getCurrentIndex()).toBe(2); // skipped global #1
+    player.channelDown();
+    expect(player.getCurrentIndex()).toBe(0);
+  });
+
   it('saves on switching to VOD (playVod)', () => {
     player.play(0, CATCHUP);
     video.currentTime = 90;

--- a/src/components/player.ts
+++ b/src/components/player.ts
@@ -74,6 +74,8 @@ export class Player {
   private manifestVariants: StreamVariant[] = []; // HLS master variants for best-effort codec readout
   private vodInfo: MediaInfo | null = null; // container-header stream info for the active VOD (codec/fps/HDR)
   private stallWatchdog: StallWatchdog;
+  /** Resolve CH+/CH− within the active group; null → fall back to the full list. */
+  private resolveNeighbor: (delta: 1 | -1) => number | null = () => null;
   constructor(
     container: HTMLElement,
     onBack: () => void,
@@ -908,7 +910,17 @@ export class Player {
     };
   }
 
+  /** Wire after Sidebar exists — keeps CH+/CH− inside Favorites / the active group. */
+  setNeighborResolver(resolve: (delta: 1 | -1) => number | null): void {
+    this.resolveNeighbor = resolve;
+  }
+
   channelUp(): void {
+    const scoped = this.resolveNeighbor(1);
+    if (scoped != null) {
+      this.play(scoped);
+      return;
+    }
     const len = PlaylistService.channels.length;
     if (!len) return;
     const next = this.currentIndex >= 0
@@ -918,6 +930,11 @@ export class Player {
   }
 
   channelDown(): void {
+    const scoped = this.resolveNeighbor(-1);
+    if (scoped != null) {
+      this.play(scoped);
+      return;
+    }
     const len = PlaylistService.channels.length;
     if (!len) return;
     const next = this.currentIndex >= 0

--- a/src/components/sidebar.test.ts
+++ b/src/components/sidebar.test.ts
@@ -940,4 +940,36 @@ describe('Sidebar', () => {
       expect(onSelect).toHaveBeenCalledWith(2); // Charlie is global index 2, not filtered 0
     });
   });
+
+  describe('neighborChannel (CH+/CH− zap scope)', () => {
+    it('walks Favorites by group order, not the global All index', () => {
+      // Fixture already marks Bravo (1) as favorite. Add Charlie (2) so the
+      // favorite list is [Bravo, Charlie] — non-contiguous in the All list.
+      channels[1].favorite = true;
+      channels[2].favorite = true;
+      channels[0].favorite = false;
+      sidebar.setLocation('builtin:favorites');
+      getCurrentIndex.mockReturnValue(1); // playing Bravo (#2 in All)
+      expect(sidebar.neighborChannel(1)).toBe(2); // next favorite = Charlie, not All #3
+      getCurrentIndex.mockReturnValue(2);
+      expect(sidebar.neighborChannel(1)).toBe(1); // wrap within Favorites → Bravo
+      expect(sidebar.neighborChannel(-1)).toBe(1); // previous = Bravo
+      channels[2].favorite = false;
+    });
+
+    it('walks a source group without spilling into All', () => {
+      sidebar.setLocation('source:News');
+      getCurrentIndex.mockReturnValue(0); // Alpha
+      expect(sidebar.neighborChannel(1)).toBe(1); // Bravo (also News)
+      getCurrentIndex.mockReturnValue(1);
+      expect(sidebar.neighborChannel(1)).toBe(0); // wrap, not Charlie/Sports
+    });
+
+    it('enters the active group when the playing channel is outside it', () => {
+      sidebar.setLocation('source:Sports');
+      getCurrentIndex.mockReturnValue(0); // Alpha is News, not Sports
+      expect(sidebar.neighborChannel(1)).toBe(2); // first Sports channel
+      expect(sidebar.neighborChannel(-1)).toBe(2); // last Sports channel
+    });
+  });
 });

--- a/src/components/sidebar.ts
+++ b/src/components/sidebar.ts
@@ -104,6 +104,44 @@ export class Sidebar {
     return this.isVisible;
   }
 
+  /** Active group + playlist filter (shared with the channel-list view). */
+  getLocation(): { group: ChannelGroupId; playlist: string } {
+    return { group: this.group, playlist: this.playlist };
+  }
+
+  /** Align the sidebar filter with the channel list (or another browse surface). */
+  setLocation(group: ChannelGroupId, playlist = ''): void {
+    if (this.group === group && this.playlist === playlist) return;
+    this.group = group;
+    this.playlist = playlist;
+    this.searchQuery = '';
+    this.channelSource = null;
+    this.groupSource = null;
+    if (this.isVisible) {
+      this.focusCurrentChannel(false);
+      this.render();
+    }
+  }
+
+  /**
+   * Next/previous channel within the active group (and playlist / recent /
+   * search filter). Returns a global playlist index, or null when the filtered
+   * list is empty (caller should fall back to All).
+   */
+  neighborChannel(delta: 1 | -1): number | null {
+    this.channelSource = null;
+    const len = this.getChannelCount();
+    if (!len) return null;
+    const pos = this.findChannelPosition(this.getCurrentIndex());
+    // If the playing channel isn't in this group (e.g. just switched category),
+    // enter the list from the start (CH+) or end (CH−) instead of the All list.
+    const nextPos = pos < 0
+      ? (delta > 0 ? 0 : len - 1)
+      : (pos + delta + len) % len;
+    const entry = this.getChannelEntry(nextPos);
+    return entry ? entry.globalIdx : null;
+  }
+
   get pointerDismissX(): number {
     const groupWidth = this.el?.querySelector<HTMLElement>('.sidebar-group-panel')
       ?.getBoundingClientRect().width || GROUP_PANEL_MIN_WIDTH;


### PR DESCRIPTION
Allow to switch channels within same sidebar context